### PR TITLE
Allow user to set alternative platform using ALT_PLATFORM env var.

### DIFF
--- a/boinc-client/cc_config.xml
+++ b/boinc-client/cc_config.xml
@@ -1,0 +1,5 @@
+<cc_config>
+    <options>
+        <alt_platform>aarch64-unknown-linux-gnu</alt_platform>
+    </options>
+</cc_config>


### PR DESCRIPTION
Gives the user more flexibility in setting an alternative platform if the device is detected as not supported by the project.

Raspberry Pi 4's detected as `arm-unknown-linux-gnueabihf` can be set to `aarch64-unknown-linux-gnu`.

The script checks for the ALT_PLATFORM environment variable and sets the variable in the cc_config.xml file.

List of platforms: https://boinc.berkeley.edu/trac/wiki/BoincPlatforms

Closes #11 .

Change-type: patch
Signed-off-by: Carlo Miguel Cruz <carloc@balena.io>