### PR TITLE
Adjust task limiting parameters

### DIFF
--- a/boinc-client/global_prefs_override.xml
+++ b/boinc-client/global_prefs_override.xml
@@ -1,6 +1,6 @@
 <global_preferences>
    <max_ncpus_pct>100.000000</max_ncpus_pct>
-   <ram_max_used_busy_pct>100.000000</ram_max_used_busy_pct>
-   <ram_max_used_idle_pct>100.000000</ram_max_used_idle_pct>
+   <ram_max_used_busy_pct>95.000000</ram_max_used_busy_pct>
+   <ram_max_used_idle_pct>95.000000</ram_max_used_idle_pct>
    <cpu_usage_limit>100.000000</cpu_usage_limit>
 </global_preferences>

--- a/boinc-client/start.sh
+++ b/boinc-client/start.sh
@@ -11,9 +11,9 @@ fi
 
 totalmem=$(awk '/^MemTotal:/{print $2}' /proc/meminfo)
 
-if [ "$totalmem" -lt "2500000" ]; then
-  echo "Less than 2.5GB RAM - running single concurrent task"
-  exec boinc --dir /usr/app/boinc/ --allow_remote_gui_rpc --fetch_minimal_work
-else
-  exec boinc --dir /usr/app/boinc/ --allow_remote_gui_rpc
+if [ "$totalmem" -lt "1500000" ]; then
+  echo "Less than 1.5GB RAM - running single concurrent task"
+  sed -i -e 's|<max_ncpus_pct>[0-9a-z.]\{1,\}</max_ncpus_pct>|<max_ncpus_pct>25.000000</max_ncpus_pct>|g' /usr/app/boinc/global_prefs_override.xml
 fi
+
+exec boinc --dir /usr/app/boinc/ --allow_remote_gui_rpc


### PR DESCRIPTION
Limit to 95% RAM usage for all devices, and also to a single core on
<1.5GB devices.

Change-type: patch
Signed-off-by: Chris Crocker-White <chriscw@balena.io>